### PR TITLE
Refactored create-graph to allow tx annotation

### DIFF
--- a/src/spark/sparkspec/datomic.clj
+++ b/src/spark/sparkspec/datomic.clj
@@ -1144,8 +1144,8 @@
                    (swap! tmps conj [updates eid])) %))
            (#(with-meta % (assoc (meta %) :eid eid)))))))
 
-(t/ann ^:no-check create-graph! (t/All [a] [ConnCtx a -> a]))
-(defn create-graph! [conn-ctx new-si-coll]
+(t/ann ^:no-check create-graph (t/All [a] [ConnCtx a -> a]))
+(defn create-graph [conn-ctx new-si-coll]
   (let [tmps  (atom [])
         specs (map get-spec new-si-coll)
         data  (let [db (db/db (:conn conn-ctx))]
@@ -1158,7 +1158,19 @@
                      new-si-coll specs))
         tmpids (map (comp :eid meta) data)
         data   (apply concat data)
-        txn-result @(db/transact (:conn conn-ctx) data)]
+        txn-id (db/tempid :db.part/tx)
+        data (if-let [tl (:transaction-log conn-ctx)]
+                  (->> (sp->transactions (db/db (:conn conn-ctx)) tl) ; hijack db/id to point to txn.
+                       (map #(assoc % :db/id txn-id))
+                       (concat data))
+                  data)]
+    (with-meta data {:tmpids tmpids :specs specs})))
+
+(t/ann ^:no-check create-graph! (t/All [a] [ConnCtx a -> a]))
+(defn create-graph! [conn-ctx new-si-coll]
+  (let [data (create-graph conn-ctx new-si-coll)        
+        {:keys [tmpids specs]} (meta data)
+        txn-result @(db/transact (:conn conn-ctx) data)]    
     ;; db side effect has occurred
     (let [db (db/db (:conn conn-ctx))
           db-si-coll (map #(some->> (db/resolve-tempid db (:tempids txn-result) %1)


### PR DESCRIPTION
create! didn't seem to let you annotate transactions like most of the other functions, plus I split the method up so you can see the data before it goes to transact.