### PR TITLE
Check the class, not the hmap

### DIFF
--- a/src/spark/spec_tacular.clj
+++ b/src/spark/spec_tacular.clj
@@ -375,7 +375,8 @@
         opts (cons [:db-ref `(t/Option t/Any)] opts)
         opts (cons [:spec-tacular/spec `(t/Option t/Keyword)] opts)]
     ;; TODO: aren't there required fields?
-    `(t/HMap :complete? true :optional ~(into {} opts)))) 
+    #_`(t/HMap :complete? true :optional ~(into {} opts))
+    (spec->class spec)))
 
 (defn- spec->type [spec]
   (condp instance? spec


### PR DESCRIPTION
What do you think of this? When we generate schemas from the type, this means we only check the for the correct instance. The constructors do their own field validation anyhow.

(price is we lose static typing w/o :no-check)