### PR TITLE
Allow docstrings on defspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the following in return:
 * **Representation of Datomic entities as maps** that verify (upon
    creation and association) that entity attributes have the correct
    fields, and in turn, the correct types
-   
+
 * **Core Typed aliases for each spec**
 
 * **Specialized query language** with a map-like syntax that allows
@@ -57,7 +57,7 @@ the following in return:
 ;; a Mailbox. It may also link in any number of Occupants.
 (defspec House
   (:link [occupants :is-many :Occupant])
-  [mailbox :is-a :Mailbox]               
+  [mailbox :is-a :Mailbox]
   [color :is-a :Color :required])
 
 (defenum Color   ;; Houses can only be green or orange..
@@ -65,6 +65,12 @@ the following in return:
 
 (defspec Mailbox              ;; Hope you don't want to get your mail
   [has-mail? :is-a :boolean]) ;; cause mailboxes only know if they have mail
+
+;; Specs can have docstrings
+(defspec Chimney
+  "Chimneys are super complicated and require documentation"
+  (:link [house :is-a House]))
+(doc Chimney) ;; Such words
 
 ;; Houses can be occupied by either People or Pets.
 (defunion Occupant :Person :Pet)

--- a/src/spark/spec_tacular.clj
+++ b/src/spark/spec_tacular.clj
@@ -626,7 +626,8 @@
 
   ```
   (defspec Name
-    [field-name docstring? arity type option ...]
+    docstring?
+    [field-name arity type option ...]
     ...)
   ```
 

--- a/src/spark/spec_tacular.clj
+++ b/src/spark/spec_tacular.clj
@@ -42,7 +42,7 @@
 
 (defn- resolve-fn [o & rest]
   (cond
-    (:spec-tacular/spec o) (:spec-tacular/spec o) 
+    (:spec-tacular/spec o) (:spec-tacular/spec o)
     (or (instance? Spec o)
         (instance? EnumSpec o)
         (instance? UnionSpec o)) (:name o)
@@ -133,7 +133,7 @@
   "Coerces `val` into something that could be put in the `kw` field of
   `spec`.  Returns `nil` only if the value is coerced to `nil`; i.e.
   if `val` does not have a `coercion` the `val` is returned unharmed."
-  [spec kw val] 
+  [spec kw val]
   (let [{[cardinality typ] :type :as item} (get-item spec kw)]
     (if (and item (some? val)) ;; this is defined in the spec, and the item is non-nil
       (case cardinality
@@ -153,7 +153,7 @@
   "Returns a sequence containing every spec in the given namespace."
   [namespace]
   (->> (ns-publics namespace)
-       (map (fn [[sym v]] 
+       (map (fn [[sym v]]
               (some-> (meta v)
                       (#(or (:spec-tacular/spec %)
                             (:spec-tacular/union %)
@@ -184,7 +184,7 @@
       (let [;; This is a work-around for being able to define
             ;; recursive types
             spec-class (get-spec-class typ)
-            is-type? (fn [v] 
+            is-type? (fn [v]
                        (if (class? spec-class)
                          (instance? spec-class v)
                          (contains? (set (:elements (get-spec typ)))
@@ -301,7 +301,7 @@
                (clojure.lang.APersistentMap/mapHash this#))
            (equals [this# ~gs]
              (= this# ~gs)))
-         
+
          (defmethod print-method ~class-name [v# ^java.io.Writer w#]
            (.write w# (spec-instance->str ~spec v# '~(ns-name *ns*))))
          (defmethod pp/simple-dispatch ~class-name [v#]
@@ -375,7 +375,7 @@
         opts (cons [:db-ref `(t/Option t/Any)] opts)
         opts (cons [:spec-tacular/spec `(t/Option t/Keyword)] opts)]
     ;; TODO: aren't there required fields?
-    `(t/HMap :complete? true :optional ~(into {} opts)))) 
+    `(t/HMap :complete? true :optional ~(into {} opts))))
 
 (defn- spec->type [spec]
   (condp instance? spec
@@ -390,7 +390,7 @@
         nsd-alias (symbol (str *ns*) (str alias-name))
         type  (spec->type spec)]
     `(do (t/defalias ~alias ~type)
-         (defmethod get-type ~(:name spec) [_#] 
+         (defmethod get-type ~(:name spec) [_#]
            ~(condp instance? spec
               Spec      (map->SpecType {:name (:name spec) :type-symbol nsd-alias})
               UnionSpec (map->SpecType {:name (:name spec) :type-symbol nsd-alias})
@@ -479,13 +479,13 @@
 (defn- mk-union-get-map-ctor [spec]
   (let [fac-sym (symbol (str "map->i_" (name (:name spec)) "-fixed"))]
     `(do
-       ;; the "map ctor" for an union means it's arg needs to 
+       ;; the "map ctor" for an union means it's arg needs to
        ;; be a tagged map or a record type of one of the union's ctors.
        (defn ~fac-sym [o# h#]
          (let [subspec-name# (:name (get-spec o#))]
            (assert subspec-name#
                    (str "could not find spec for "o#))
-           (assert (contains? ~(:elements spec) subspec-name#) 
+           (assert (contains? ~(:elements spec) subspec-name#)
                    (str subspec-name#" is not an element of "~(:name spec)))
            ((get-map-ctor subspec-name#) o# h#)))
        (defmethod get-map-ctor ~(:name spec) [_#] ~fac-sym))))
@@ -623,7 +623,7 @@
 
 (defmacro defspec
   "Defines a spec-tacular spec type.
-  
+
   ```
   (defspec Name
     [field-name arity type option ...]
@@ -632,7 +632,7 @@
 
   creates the spec `:Name`; where arity is either `:is-a` or
   `:is-many` and type is either another spec name or a primitive type
-  keyword. 
+  keyword.
 
   spec-tacular supports base types `:keyword`, `:string`, `:boolean`,
   `:long`, `:bigint`, `:float`, `:double`, `:bigdec`, `:instant`,
@@ -656,9 +656,11 @@
   [& stx]
   (let [s (parse-spec stx)
         {:keys [ctor-name huh-name alias-name]} (spec-meta *ns* s (meta (first stx)))
-        spec-name (make-name s identity)]
+        spec-name (make-name s identity)
+        {:keys [doc]} s]
     `(do ~(mk-type-alias s alias-name)
-         (def ~(with-meta spec-name {:spec-tacular/spec (:name s)}) ~s)
+         (def ~(with-meta spec-name {:spec-tacular/spec (:name s)
+                                     :doc doc}) ~s)
          ~(mk-record s)
          ~(mk-get-map-ctor s)
          ~(mk-huh s huh-name)
@@ -772,7 +774,7 @@
 (defn refless=
   "Given any walkable collection, returns `true` if the two
   collections would be `=` if no spec instances had `:db-ref`s.
-  
+
   Contains a fast path if both `x` and `y` have specs, otherwise
   expect bad asymptotics as each collection must be rebuilt without
   `:db-ref`s."

--- a/src/spark/spec_tacular.clj
+++ b/src/spark/spec_tacular.clj
@@ -673,16 +673,18 @@
   "Defines a spec-tacular union.
 
   ```
-  (defunion Name :SpecName ...)
+  (defunion Name docstring? :SpecName ...)
   ```
 
   where each SpecName is another spec to be added to the union."
   [& stx]
   (let [u (parse-union stx)
         {:keys [huh-name alias-name]} (spec-meta *ns* u (meta (first stx)))
-        spec-name (make-name u identity)]
+        spec-name (make-name u identity)
+        {:keys [doc]} u]
     `(do ~(mk-type-alias u alias-name)
-         (def ~(with-meta spec-name {:spec-tacular/union (:name u)}) ~u)
+         (def ~(with-meta spec-name {:spec-tacular/union (:name u)
+                                     :doc doc}) ~u)
          ~(mk-union-get-map-ctor u)
          ~(mk-union-get-spec u)
          ~(mk-huh u huh-name))))
@@ -691,7 +693,7 @@
   "Defines an enumeration of values under a parent name.
 
   ```
-  (defenum Name symbol ...)
+  (defenum Name docstring? symbol ...)
   ```
 
   The resulting enumeration recognizes `:Name/<symbol>` keywords,
@@ -701,9 +703,11 @@
   [& stx]
   (let [e (parse-enum stx)
         {:keys [huh-name alias-name]} (spec-meta *ns* e (meta (first stx)))
-        spec-name (make-name e identity)]
+        spec-name (make-name e identity)
+        {:keys [doc]} e]
     `(do ~(mk-type-alias e alias-name)
-         (def ~(with-meta spec-name {:spec-tacular/enum (:name e)}) ~e)
+         (def ~(with-meta spec-name {:spec-tacular/enum (:name e)
+                                     :doc doc}) ~e)
          ~(mk-enum-get-spec e)
          ~(mk-huh e huh-name)
          ~(mk-get-spec-class e))))

--- a/src/spark/spec_tacular.clj
+++ b/src/spark/spec_tacular.clj
@@ -626,13 +626,14 @@
 
   ```
   (defspec Name
-    [field-name arity type option ...]
+    [field-name docstring? arity type option ...]
     ...)
   ```
 
   creates the spec `:Name`; where arity is either `:is-a` or
   `:is-many` and type is either another spec name or a primitive type
-  keyword.
+  keyword. The docstring is optional; if given, it will become the
+  :doc metadata on the spec var.
 
   spec-tacular supports base types `:keyword`, `:string`, `:boolean`,
   `:long`, `:bigint`, `:float`, `:double`, `:bigdec`, `:instant`,

--- a/src/spark/spec_tacular/grammar.clj
+++ b/src/spark/spec_tacular/grammar.clj
@@ -10,22 +10,21 @@
 
 (defn parse-spec [stx & [loc]]
   (let [loc (or loc (merge {:namespace (str *ns*)} (meta stx)))]
-    (match stx
-      ([name (docstring :guard string?) & items] :seq)
-      (let [name  (keyword name)
-            items (mapcat #(parse-item % loc) items)]
-        (map->Spec {:name name
-                    :doc docstring
-                    :items items
-                    :syntax (cons 'defspec stx)}))
-      ([name & items] :seq)
-      (let [name  (keyword name)
-            items (mapcat #(parse-item % loc) items)]
-        (map->Spec {:name name
-                    :items items
-                    :syntax (cons 'defspec stx)}))
-      :else (throw (ex-info "expecting name followed by sequence of items"
-                            (merge loc {:syntax stx}))))))
+    (letfn [(build [name docstring items]
+              (let [name  (keyword name)
+                    items (mapcat #(parse-item % loc) items)
+                    attrs (cond-> {:name name
+                                   :items items
+                                   :syntax (cons 'defspec stx)}
+                            docstring (assoc :doc docstring))]
+                (map->Spec attrs)))]
+      (match stx
+        ([name (docstring :guard string?) & items] :seq)
+        ,(build name docstring items)
+        ([name & items] :seq)
+        ,(build name nil items)
+        :else (throw (ex-info "expecting name followed by sequence of items"
+                              (merge loc {:syntax stx})))))))
 
 (defn parse-item [stx & [loc]]
   (match stx
@@ -67,53 +66,46 @@
 
 (defn parse-union [stx & [loc]]
   (let [loc (or loc (merge {:namespace (str *ns*)} (meta stx)))]
-    (match stx
-      ([name (docstring :guard string?) & specs] :seq)
-      (let [name (keyword name)]
-        (map->UnionSpec {:name name
-                         :doc docstring
-                         :elements (into #{} specs)}))
-      ([name & specs] :seq)
-      (let [name (keyword name)]
-        (map->UnionSpec {:name name
-                         :elements (into #{} specs)}))
-      :else (throw (ex-info "expecting name followed by sequence of specs"
-                            (merge loc {:syntax stx}))))))
+    (letfn [(build [name docstring specs]
+              (let [attrs (cond-> {:name (keyword name)
+                                   :elements (into #{} specs)}
+                            docstring
+                            (assoc :doc docstring))]
+                (map->UnionSpec attrs)))]
+      (match stx
+        ([name (docstring :guard string?) & specs] :seq)
+        ,(build name docstring specs)
+        ([name & specs] :seq)
+        ,(build name nil specs)
+        :else (throw (ex-info "expecting name followed by sequence of specs"
+                              (merge loc {:syntax stx})))))))
 
 ;; -----------------------------------------------------------------------------
 ;; enum
 
 (defn parse-enum [stx & [loc]]
   (let [loc (or loc (merge {:namespace (str *ns*)} (meta stx)))]
-    (match stx
-      ([name (docstring :guard string?) & values] :seq)
-      (do (when-not (symbol? name)
-            (throw (ex-info (str "enumeration name must be a symbol, given " (type name))
-                            (merge loc {:syntax stx}))))
-          (when-not (every? symbol? values)
-            (throw (ex-info "some enumeration values are not symbols"
-                            (merge loc {:syntax stx :problems (filter (complement symbol?) values)}))))
-          (when (empty? values)
-            (throw (ex-info "enumeration can't be empty"
-                            (merge loc {:syntax stx}))))
-          (let [ename (keyword name)
-                vals  (map #(keyword (str name) (str %)) values)]
-            (map->EnumSpec {:name ename
-                            :doc docstring
-                            :values (into #{} vals)})))
-      ([name & values] :seq)
-      (do (when-not (symbol? name)
-            (throw (ex-info (str "enumeration name must be a symbol, given " (type name))
-                            (merge loc {:syntax stx}))))
-          (when-not (every? symbol? values)
-            (throw (ex-info "some enumeration values are not symbols"
-                            (merge loc {:syntax stx :problems (filter (complement symbol?) values)}))))
-          (when (empty? values)
-            (throw (ex-info "enumeration can't be empty"
-                            (merge loc {:syntax stx}))))
-          (let [ename (keyword name)
-                vals  (map #(keyword (str name) (str %)) values)]
-            (map->EnumSpec {:name ename
-                            :values (into #{} vals)})))
-      :else (throw (ex-info "expecting name followed by arbitrary number of symbols"
-                            (merge loc {:syntax stx}))))))
+    (letfn [(build [name docstring values]
+              (do (when-not (symbol? name)
+                    (throw (ex-info (str "enumeration name must be a symbol, given " (type name))
+                                    (merge loc {:syntax stx}))))
+                  (when-not (every? symbol? values)
+                    (throw (ex-info "some enumeration values are not symbols"
+                                    (merge loc {:syntax stx :problems (filter (complement symbol?) values)}))))
+                  (when (empty? values)
+                    (throw (ex-info "enumeration can't be empty"
+                                    (merge loc {:syntax stx}))))
+                  (let [ename (keyword name)
+                        vals  (map #(keyword (str name) (str %)) values)
+                        attrs (cond-> {:name ename
+                                       :values (into #{} vals)}
+                                docstring
+                                (assoc :doc docstring))]
+                    (map->EnumSpec attrs))))]
+      (match stx
+        ([name (docstring :guard string?) & values] :seq)
+        ,(build name docstring values)
+        ([name & values] :seq)
+        ,(build name nil values)
+        :else (throw (ex-info "expecting name followed by arbitrary number of symbols"
+                              (merge loc {:syntax stx})))))))

--- a/src/spark/spec_tacular/spec.clj
+++ b/src/spark/spec_tacular/spec.clj
@@ -84,6 +84,6 @@
            [:calendarday org.joda.time.DateTime `org.joda.time.DateTime timec/to-date-time]
            [:uuid java.util.UUID `java.util.UUID #(if (string? %) (java.util.UUID/fromString %) %)]
            [:uri java.net.URI `java.net.URI nil]
-           [:bytes Bytes `Bytes nil]])) 
+           [:bytes Bytes `Bytes nil]]))
 
 (def ^:constant core-types (into #{} (keys type-map)))

--- a/test/spark/spec_tacular_test.clj
+++ b/test/spark/spec_tacular_test.clj
@@ -24,7 +24,7 @@
     (is (some? (get-spec :TestSpec1 :TestSpec1)))
     (is (some? (get-spec {:spec-tacular/spec :TestSpec1})))
     (is (some? (get-spec (get-spec :TestSpec1))))
-    
+
     (let [good (testspec1 {:val1 3 :val2 "hi"})]
       (is (testspec1? good))
       (is (= (:val1 good) 3))
@@ -43,13 +43,13 @@
   (testing "invalid"
     (is (not (testspec1? {:val1 3 :val2 "hi"}))
         "not a record")
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"required" 
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"required"
                           (testspec1 {:val1 nil}))
         "missing required field")
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"required"
                           (testspec1 {:val2 1}))
         "missing required field")
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"invalid type" 
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"invalid type"
                           (testspec1 {:val1 0 :val2 1}))
         "wrong type")
     (is (thrown? clojure.lang.ExceptionInfo (testspec1 {:val1 3 :extra-key true}))
@@ -114,7 +114,7 @@
          (get-spec :TestSpec2)))
   (is (= (:elements (get-spec :testunion))
          #{:TestSpec2 :TestSpec3}))
-  
+
   (is (testunion? (testspec2 {})))
   (is (instance? spark.spec_tacular.spec.UnionSpec (get-spec :testunion)))
   (is (check-component! (get-spec :ES) :foo (testspec2 {})))
@@ -188,7 +188,7 @@
   (let [l1 (link {:ts3 (assoc (testspec3) :db-ref 1)})]
     (is (= (refless l1)
            (link {:ts3 (testspec3)}))))
-  
+
   (let [l1 (link {:ts3 (testspec3 {:db-ref 1}) :db-ref 3})
         l2 (link {:ts3 (testspec3 {:db-ref 2}) :db-ref 4})]
     (is (refless= [[[l1]]] [[[l2]]]) "refless equality"))
@@ -263,6 +263,16 @@
                      :name "Mary",
                      :pets #{(cat {:name "Ringo"}) (dog {:name "George"})}}]))))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; docstrings
+(defspec Complicated
+  "A complicated thing that really needs documentation"
+  [name :is-a :string])
+
+(deftest test-docstrings
+  (is (= "A complicated thing that really needs documentation"
+         (:doc (meta #'Complicated)))))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; ns
@@ -274,7 +284,7 @@
                     #{:TestSpec1 :TestSpec2 :TestSpec3 :TestSpec4 :TestSpec5
                       :testunion :ES :ESParent :UnionFoo :UnionForward :A :B
                       :Link :Human :TestSpec6 :TestSpec7 :IsEnum :HasEnum
-                      :TestSpec8})]
-    (is (= (count both) 19) "total number of specs")
+                      :TestSpec8 :Complicated})]
+    (is (= (count both) 20) "total number of specs")
     (is (nil? b) "no missing specs")
     (is (nil? a) "no extra specs")))

--- a/test/spark/spec_tacular_test.clj
+++ b/test/spark/spec_tacular_test.clj
@@ -269,9 +269,22 @@
   "A complicated thing that really needs documentation"
   [name :is-a :string])
 
+(defunion Complexity
+  "Complexity is complicated"
+  :Complicated)
+
+(defenum Complications
+  "Simple isn't easy"
+  Simple
+  Easy)
+
 (deftest test-docstrings
   (is (= "A complicated thing that really needs documentation"
-         (:doc (meta #'Complicated)))))
+         (:doc (meta #'Complicated))))
+  (is (= "Complexity is complicated"
+         (:doc (meta #'Complexity))))
+  (is (= "Simple isn't easy"
+         (:doc (meta #'Complications)))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -284,7 +297,7 @@
                     #{:TestSpec1 :TestSpec2 :TestSpec3 :TestSpec4 :TestSpec5
                       :testunion :ES :ESParent :UnionFoo :UnionForward :A :B
                       :Link :Human :TestSpec6 :TestSpec7 :IsEnum :HasEnum
-                      :TestSpec8 :Complicated})]
-    (is (= (count both) 20) "total number of specs")
+                      :TestSpec8 :Complicated :Complexity :Complications})]
+    (is (= (count both) 22) "total number of specs")
     (is (nil? b) "no missing specs")
     (is (nil? a) "no extra specs")))


### PR DESCRIPTION
Assuming this is desirable and a good approach, I'll submit something
similar for defunion and defenum.

Note this incidentally cleans up trailing whitespace, which I'm happy to
submit separately or not at all, if the diff foo is annoying.
